### PR TITLE
Fix version incompatibility

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MatthieuDartiailh @greyltc @mtsolmn
+* @MatthieuDartiailh @mtsolmn @greyltc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @greyltc @mtsolmn
+* @MatthieuDartiailh @greyltc @mtsolmn

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@MatthieuDartiailh](https://github.com/MatthieuDartiailh/)
 * [@greyltc](https://github.com/greyltc/)
 * [@mtsolmn](https://github.com/mtsolmn/)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Home: https://github.com/pyvisa/pyvisa-py
 
 Package license: MIT
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyvisa-py-feedstock/blob/master/LICENSE.txt)
 
 Summary: Python VISA bindings for GPIB, RS232, and USB instruments
+
+Development: https://github.com/pyvisa/pyvisa-py
+
+Documentation: https://rpyc.readthedocs.io/
 
 A PyVISA backend that implements a large part of the "Virtual
 Instrument Software Architecture" (VISA) in pure Python (with the

--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Feedstock Maintainers
 =====================
 
 * [@MatthieuDartiailh](https://github.com/MatthieuDartiailh/)
-* [@greyltc](https://github.com/greyltc/)
 * [@mtsolmn](https://github.com/mtsolmn/)
+* [@greyltc](https://github.com/greyltc/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script:
     - {{ PYTHON }} -m pip install . -vv
 
@@ -24,7 +24,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - pyvisa >=1.10.1
+    - pyvisa >=1.11
     - pyserial
     - pyusb
     - typing_extensions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
     # fails because of wrong versioning number in seutp.cfg
     # issue raised with project maintainers
     - pip check
-    - python -c "import pyvisa_py.testsuite as ts; ts.testsuite().run()"
+    - python -c "import pyvisa_py.testsuite as ts; import unittest; unittest.TextTestRunner().run(ts.testsuite())"
     # backend issue with running the below test due to how
     # docker runs and pyvisa detects available visa backends
     # - python -c "import pyvisa; rm = pyvisa.ResourceManager('@py')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,14 @@ test:
   imports:
     - pyvisa
     - pyvisa.testsuite
+    - pyvisa_py
+    - pyvisa_py.protocols
+    - pyvisa_py.testsuite
   commands:
     # fails because of wrong versioning number in seutp.cfg
     # issue raised with project maintainers
     - pip check
-    - python -c "import pyvisa.testsuite.testsuite as ts; ts.run()"
+    - python -c "import pyvisa_py.testsuite as ts; ts.testsuite.run()"
     # backend issue with running the below test due to how
     # docker runs and pyvisa detects available visa backends
     # - python -c "import pyvisa; rm = pyvisa.ResourceManager('@py')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - setuptools
     - setuptools_scm
   run:
-    - python
-    - pyvisa >=1.11
+    - python >=3.6
+    - pyvisa >=1.11.0
     - pyserial
     - pyusb
     - typing_extensions
@@ -41,7 +41,7 @@ test:
     # fails because of wrong versioning number in seutp.cfg
     # issue raised with project maintainers
     - pip check
-    - python -c "import pyvisa_py.testsuite as ts; ts.testsuite.run()"
+    - python -c "import pyvisa_py.testsuite as ts; ts.testsuite().run()"
     # backend issue with running the below test due to how
     # docker runs and pyvisa detects available visa backends
     # - python -c "import pyvisa; rm = pyvisa.ResourceManager('@py')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,8 @@ test:
   commands:
     # fails because of wrong versioning number in seutp.cfg
     # issue raised with project maintainers
-    # - pip check
-    - python -c "import pyvisa.testsuite as ts; ts.run()"
+    - pip check
+    - python -c "import pyvisa.testsuite.testsuite as ts; ts.run()"
     # backend issue with running the below test due to how
     # docker runs and pyvisa detects available visa backends
     # - python -c "import pyvisa; rm = pyvisa.ResourceManager('@py')"
@@ -62,5 +62,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - MatthieuDartiailh
     - mtsolmn
     - greyltc


### PR DESCRIPTION
pyvisa-py requires pyvisa >= 1.11. Fixes #17. Without this change, a `conda install pyvisa-py` results in a broken installation.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
